### PR TITLE
fix BSD build

### DIFF
--- a/libvm/Makefile
+++ b/libvm/Makefile
@@ -16,7 +16,7 @@ emulator: emulator.c vm.c
 	$(CC) -g -o bin/$@ $^ -lSDL $(CFLAGS)
 
 as:
-	make -C as
+	$(MAKE) -C as
 	
 test: exp
 	./exp -o test.exp $(ARGS)


### PR DESCRIPTION
The makefile used in the libvm folder is incompatible with BSD make. When using gmake, the compilation will stop, because the expects make to compile the subdirectory "as", whose Makefile is also incompatible with BSD make
